### PR TITLE
docs: Specify ethhash in repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# firewood-go
+# firewood-go-ethhash
 
-firewood-go provides a Golang FFI wrapper for [Firewood](https://github.com/ava-labs/firewood/).
+firewood-go-ethhash provides a Golang FFI wrapper for [Firewood](https://github.com/ava-labs/firewood/).
 
 This repo serves serves as a mirror, maintained by Firewood CI, to include both the Firewood Golang FFI source code and attach pre-built binaries directly to source. This enables the Go toolchain to import Firewood and use the pre-built binaries with CGO without worrying about the fact it's implemented in Rust.
 
-For complete documentation, see [Firewood FFI](https://github.com/ava-labs/firewood/tree/main/ffi)
+These binaries provide an Ethereum-compatible hashing scheme, emulating that of `HashDB` and `PathDB` (see the [hashing tests](https://github.com/ava-labs/firewood/tree/main/ffi/tests/eth/eth_compatibility_test.go) for example usage). Although Firewood supports a more efficient version of  Merkle hashing for general purpose use, this is not available on these pre-built binaries, but may be provided in the future.
+
+For complete documentation, see [Firewood FFI](https://github.com/ava-labs/firewood/tree/main/ffi).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ firewood-go-ethhash provides a Golang FFI wrapper for [Firewood](https://github.
 
 This repo serves serves as a mirror, maintained by Firewood CI, to include both the Firewood Golang FFI source code and attach pre-built binaries directly to source. This enables the Go toolchain to import Firewood and use the pre-built binaries with CGO without worrying about the fact it's implemented in Rust.
 
-These binaries provide an Ethereum-compatible hashing scheme, emulating that of `HashDB` and `PathDB`. For example usage, see the [firewood hashing tests](https://github.com/ava-labs/firewood/tree/main/ffi/tests/eth/eth_compatibility_test.go).
+These binaries provide an Ethereum-compatible hashing scheme, emulating that of `HashDB` and `PathDB`. For example usage, see the [Firewood hashing tests](https://github.com/ava-labs/firewood/tree/main/ffi/tests/eth/eth_compatibility_test.go).
 	
 Although Firewood supports a more efficient version of merkle hashing for general purpose use, this is disabled for these pre-built binaries.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ firewood-go-ethhash provides a Golang FFI wrapper for [Firewood](https://github.
 
 This repo serves serves as a mirror, maintained by Firewood CI, to include both the Firewood Golang FFI source code and attach pre-built binaries directly to source. This enables the Go toolchain to import Firewood and use the pre-built binaries with CGO without worrying about the fact it's implemented in Rust.
 
-These binaries provide an Ethereum-compatible hashing scheme, emulating that of `HashDB` and `PathDB` (see the [hashing tests](https://github.com/ava-labs/firewood/tree/main/ffi/tests/eth/eth_compatibility_test.go) for example usage). Although Firewood supports a more efficient version of  Merkle hashing for general purpose use, this is not available on these pre-built binaries, but may be provided in the future.
+These binaries provide an Ethereum-compatible hashing scheme, emulating that of `HashDB` and `PathDB`. For example usage, see the [firewood hashing tests](https://github.com/ava-labs/firewood/tree/main/ffi/tests/eth/eth_compatibility_test.go).
+	
+Although Firewood supports a more efficient version of merkle hashing for general purpose use, this is disabled for these pre-built binaries.
 
 For complete documentation, see [Firewood FFI](https://github.com/ava-labs/firewood/tree/main/ffi).


### PR DESCRIPTION
After renaming the repo to specify the hashing scheme, the `README.MD` file needed updated. Note that the license file does not contain any occurrences.